### PR TITLE
Cleanup to reduce complexity and use JSON cache instead of text based.

### DIFF
--- a/kmp-readiness/src/main/kotlin/com/handstandsam/kmpreadiness/internal/ReadinessDataCalculator.kt
+++ b/kmp-readiness/src/main/kotlin/com/handstandsam/kmpreadiness/internal/ReadinessDataCalculator.kt
@@ -92,7 +92,7 @@ internal class ReadinessDataCalculator(private val target: Project) {
                     NotReadyReasonType.IncompatibleDependencies,
                     buildString {
                         dependencyAnalysis.incompatible.forEach {
-                            appendLine("* $it")
+                            appendLine("* ${it.gav.id}")
                         }
                     }
                 )

--- a/kmp-readiness/src/main/kotlin/com/handstandsam/kmpreadiness/internal/models/KmpReadyResult.kt
+++ b/kmp-readiness/src/main/kotlin/com/handstandsam/kmpreadiness/internal/models/KmpReadyResult.kt
@@ -2,41 +2,32 @@ package com.handstandsam.kmpreadiness.internal.models
 
 import kotlinx.serialization.Serializable
 
+internal interface HasGav {
+    val gav: Gav
+}
+
 @Serializable
-internal sealed class KmpReadyResult() {
+internal sealed class KmpReadyResult {
     @Serializable
 
-    sealed class Allowed : KmpReadyResult() {
+    sealed class Allowed : HasGav, KmpReadyResult() {
 
         @Serializable
         data class FromRemote(
-            val gav: Gav,
+            override val gav: Gav,
             val metadataUrl: String,
         ) : Allowed()
 
         @Serializable
         data class Excluded(
-            val gav: Gav,
-        ) : Allowed()
-
-        @Serializable
-        data class FromCache(
-            val gav: Gav,
+            override val gav: Gav,
         ) : Allowed()
     }
 
     @Serializable
-    sealed class NotAllowed : KmpReadyResult() {
-        @Serializable
-        data class FromCache(
-            val gav: Gav,
-        ) : NotAllowed()
-
-        @Serializable
-        data class FromRemote(
-            val gav: Gav,
-            val attemptedUrls: List<String> = listOf(),
-        ) : NotAllowed()
-    }
+    data class NotAllowed(
+        override val gav: Gav,
+        val attemptedUrls: List<String> = listOf(),
+    ) : HasGav, KmpReadyResult()
 }
 


### PR DESCRIPTION
Uses a single `json` file for the cache instead of multiple text files.  This allow us to save more information regarding the source of the `kotlin-tooling-metadata.json` and places we have looked.  Eventually we could get smarter by using this data.